### PR TITLE
Fixed the issue with call park

### DIFF
--- a/webex-calling-calls-api.json
+++ b/webex-calling-calls-api.json
@@ -1152,7 +1152,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"callId\": \"{{_callId}}\",\n  \"destination\": \"{{PARK_DESTINATION}}\"\"\n}",
+							"raw": "{\n  \"callId\": \"{{_callId}}\",\n  \"destination\": \"{{PARK_DESTINATION}}\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
Call Park body had 2 double quotes making the request body json invalid. Hence that test was failing. Fixed the issue.